### PR TITLE
Add support for importing sellable item bundles

### DIFF
--- a/engine/Plugin.Hunk.Catalog.Test/SellableItemEntityImport/BundleComponentMapper.cs
+++ b/engine/Plugin.Hunk.Catalog.Test/SellableItemEntityImport/BundleComponentMapper.cs
@@ -1,0 +1,44 @@
+﻿using Plugin.Hunk.Catalog.Mappers;
+using Sitecore.Commerce.Core;
+using Sitecore.Commerce.Plugin.Catalog;
+using System.Linq;
+
+namespace Plugin.Hunk.Catalog.Test.SellableItemEntityImport
+{
+    public class BundleComponentMapper : BaseBundleComponentMapper<SourceBundle>
+    {
+        public BundleComponentMapper(SourceBundle bundle, 
+            CommerceEntity commerceEntity, 
+            CommerceCommander commerceCommander, 
+            CommercePipelineExecutionContext context)
+            :base(bundle, commerceEntity, commerceCommander, context)
+        { }
+
+        protected override void Map(BundleComponent component)
+        {
+            component.BundleType = SourceEntity.BundleType;
+
+            component.BundleItems.RemoveAll(bi => !SourceEntity.BundleItems.Any(sbi => sbi.ItemId == bi.SellableItemId));
+
+            foreach (var sbi in SourceEntity.BundleItems)
+            {
+                var bundleItem = component.BundleItems.FirstOrDefault(bi => bi.SellableItemId == sbi.ItemId);
+                if (bundleItem == null)
+                {
+                    bundleItem = new BundleItem();
+
+                    bundleItem.SellableItemId = sbi.ItemId;
+                    component.BundleItems.Add(bundleItem);
+                }
+
+                bundleItem.Name = sbi.Name;
+                bundleItem.Quantity = sbi.Quantity;
+            }
+        }
+
+        protected override void MapLocalizeValues(BundleComponent component)
+        {
+
+        }
+    }
+}

--- a/engine/Plugin.Hunk.Catalog.Test/SellableItemEntityImport/SourceBundle.cs
+++ b/engine/Plugin.Hunk.Catalog.Test/SellableItemEntityImport/SourceBundle.cs
@@ -1,0 +1,39 @@
+﻿using Plugin.Hunk.Catalog.Abstractions;
+using Plugin.Hunk.Catalog.Metadata;
+using Sitecore.Commerce.Core;
+using System.Collections.Generic;
+
+namespace Plugin.Hunk.Catalog.Test.SellableItemEntityImport
+{
+    public class SourceBundle : IEntity
+    {
+        public SourceBundle()
+        {
+            Tags = new List<Tag>();
+            BundleItems = new List<SourceBundleItem>();
+        }
+
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+
+        public string DisplayName { get; set; }
+
+        public string Description { get; set; }
+
+        public string Brand { get; set; }
+
+        public string Manufacturer { get; set; }
+
+        public string TypeOfGood { get; set; }
+
+        public IList<Tag> Tags { get; set; }
+
+        [Parents()]
+        public IList<string> Parents { get; set; }
+
+        public string BundleType { get; set; }
+
+        public IList<SourceBundleItem> BundleItems { get; set; }
+    }
+}

--- a/engine/Plugin.Hunk.Catalog.Test/SellableItemEntityImport/SourceBundle.cs
+++ b/engine/Plugin.Hunk.Catalog.Test/SellableItemEntityImport/SourceBundle.cs
@@ -10,6 +10,7 @@ namespace Plugin.Hunk.Catalog.Test.SellableItemEntityImport
         public SourceBundle()
         {
             Tags = new List<Tag>();
+            Parents = new List<string>();
             BundleItems = new List<SourceBundleItem>();
         }
 

--- a/engine/Plugin.Hunk.Catalog.Test/SellableItemEntityImport/SourceBundleImportHandler.cs
+++ b/engine/Plugin.Hunk.Catalog.Test/SellableItemEntityImport/SourceBundleImportHandler.cs
@@ -1,0 +1,52 @@
+﻿using System.Linq;
+using Plugin.Hunk.Catalog.ImportHandlers;
+using Sitecore.Commerce.Core;
+using Sitecore.Commerce.Plugin.Catalog;
+
+namespace Plugin.Hunk.Catalog.Test.SellableItemEntityImport
+{
+    public class SourceBundleImportHandler : BundleImportHandler<SourceBundle>
+    {
+        public SourceBundleImportHandler(string sourceProduct, CommerceCommander commerceCommander, CommercePipelineExecutionContext context)
+            : base(sourceProduct, commerceCommander, context)
+        {
+        }
+
+        protected override void Initialize()
+        {
+            ProductId = SourceEntity.Id;
+            Name = SourceEntity.Name;
+            DisplayName = SourceEntity.DisplayName;
+            Description = SourceEntity.Description;
+            Brand = SourceEntity.Brand;
+            Manufacturer = SourceEntity.Manufacturer;
+            TypeOfGood = SourceEntity.TypeOfGood;
+            Tags = SourceEntity.Tags.Select(t=>t.Name).ToList();
+
+            BundleType = SourceEntity.BundleType;
+
+            BundleItems = SourceEntity.BundleItems.Select(x => new BundleItem {
+                SellableItemId = x.ItemId,
+                Name = x.Name,
+                Quantity = x.Quantity 
+            }).ToList();
+        }
+        
+        public override void Map()
+        {
+            CommerceEntity.Name = SourceEntity.Name;
+            CommerceEntity.DisplayName = SourceEntity.DisplayName;
+            CommerceEntity.Description = SourceEntity.Description;
+            CommerceEntity.Brand = SourceEntity.Brand;
+            CommerceEntity.Manufacturer = SourceEntity.Manufacturer;
+            CommerceEntity.TypeOfGood = SourceEntity.TypeOfGood;
+            CommerceEntity.Tags = SourceEntity.Tags;
+        }
+
+        protected override void MapLocalizeValues(SourceBundle localizedSourceEntity, SellableItem localizedTargetEntity)
+        {
+            localizedTargetEntity.DisplayName = localizedSourceEntity.DisplayName;
+            localizedTargetEntity.Description = localizedSourceEntity.Description;
+        }
+    }
+}

--- a/engine/Plugin.Hunk.Catalog.Test/SellableItemEntityImport/SourceBundleItem.cs
+++ b/engine/Plugin.Hunk.Catalog.Test/SellableItemEntityImport/SourceBundleItem.cs
@@ -1,0 +1,14 @@
+﻿namespace Plugin.Hunk.Catalog.Test.SellableItemEntityImport
+{
+    public class SourceBundleItem
+    {
+        public SourceBundleItem()
+        {
+
+        }
+
+        public string ItemId { get; set; }
+        public string Name { get; set; }
+        public int Quantity { get; set; }
+    }
+}

--- a/engine/Plugin.Hunk.Catalog/ConfigureSitecore.cs
+++ b/engine/Plugin.Hunk.Catalog/ConfigureSitecore.cs
@@ -43,6 +43,7 @@ namespace Plugin.Hunk.Catalog
                         .Add<UpdateEntityBlock>()
                         .Add<SetEntityComponentsBlock>()
                         .Add<ImportEntityVariantsBlock>()
+                        .Add<ImportBundleBlock>()
                         .Add<PersistEntityBlock>();
                 })
                 .AddPipeline<IAssociatePriceBookPipeline, AssociatePriceBookPipeline>(configure =>

--- a/engine/Plugin.Hunk.Catalog/Constants.cs
+++ b/engine/Plugin.Hunk.Catalog/Constants.cs
@@ -78,7 +78,9 @@
 
         public const string SetEntityComponentsBlock = "CatalogImport.Framework.block.SetEntityComponents";
 
-        public const string ResolveComponentMapperBlock = "CatalogImport.Framework.block.ResolveComponentMapper"; 
+        public const string ResolveComponentMapperBlock = "CatalogImport.Framework.block.ResolveComponentMapper";
+
+        public const string ImportBundleBlock = "CatalogImport.Framework.block.ImportBundle";
 
         public const string ImportEntityVariantsBlock = "CatalogImport.Framework.block.ImportEntityVariants";
 

--- a/engine/Plugin.Hunk.Catalog/ImportHandlers/BundleImportHandler.cs
+++ b/engine/Plugin.Hunk.Catalog/ImportHandlers/BundleImportHandler.cs
@@ -1,0 +1,31 @@
+﻿using Plugin.Hunk.Catalog.Abstractions;
+using Sitecore.Commerce.Core;
+using Sitecore.Commerce.Plugin.Catalog;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Plugin.Hunk.Catalog.ImportHandlers
+{
+    public abstract class BundleImportHandler<TSourceEntity> : SellableItemImportHandler<TSourceEntity>
+        where TSourceEntity : IEntity
+    {
+        protected string BundleType { get; set; }
+
+        protected IList<BundleItem> BundleItems { get; set; }
+
+        protected BundleImportHandler(string sourceEntity, CommerceCommander commerceCommander, CommercePipelineExecutionContext context)
+            : base(sourceEntity, commerceCommander, context)
+        {
+            BundleItems = new List<BundleItem>();
+        }
+
+        public override async Task<CommerceEntity> Create()
+        {
+            Initialize();
+            var command = CommerceCommander.Command<CreateBundleCommand>();
+            CommerceEntity = await command.Process(Context.CommerceContext, BundleType, ProductId, Name, DisplayName, Description, Brand, Manufacturer, TypeOfGood, Tags.ToArray(), BundleItems);
+            return CommerceEntity;
+        }
+    }
+}

--- a/engine/Plugin.Hunk.Catalog/Mappers/BaseBundleComponentMapper.cs
+++ b/engine/Plugin.Hunk.Catalog/Mappers/BaseBundleComponentMapper.cs
@@ -1,0 +1,22 @@
+﻿using Plugin.Hunk.Catalog.Abstractions;
+using Sitecore.Commerce.Core;
+using Sitecore.Commerce.Plugin.Catalog;
+
+namespace Plugin.Hunk.Catalog.Mappers
+{
+    public abstract class BaseBundleComponentMapper<TSourceEntity> : BaseCommerceEntityComponentMapper<TSourceEntity, BundleComponent>
+    where TSourceEntity : IEntity
+    {
+        protected BaseBundleComponentMapper(TSourceEntity sourceEntity, CommerceEntity commerceEntity, CommerceCommander commerceCommander, CommercePipelineExecutionContext context)
+        : base(sourceEntity, commerceEntity, commerceCommander, context)
+        {
+
+        }
+
+        protected BaseBundleComponentMapper(TSourceEntity sourceEntity, IComponentHandler componentHandler, CommerceCommander commerceCommander, CommercePipelineExecutionContext context)
+            : base(sourceEntity, componentHandler, commerceCommander, context)
+        {
+
+        }
+    }
+}

--- a/engine/Plugin.Hunk.Catalog/Pipelines/Blocks/ImportBundleBlock.cs
+++ b/engine/Plugin.Hunk.Catalog/Pipelines/Blocks/ImportBundleBlock.cs
@@ -1,0 +1,163 @@
+﻿using Plugin.Hunk.Catalog.Extensions;
+using Plugin.Hunk.Catalog.Model;
+using Plugin.Hunk.Catalog.Pipelines.Arguments;
+using Serilog;
+using Sitecore.Commerce.Core;
+using Sitecore.Commerce.Plugin.Catalog;
+using Sitecore.Commerce.Plugin.SQL;
+using Sitecore.Framework.Pipelines;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Plugin.Hunk.Catalog.Pipelines.Blocks
+{
+    [PipelineDisplayName(Constants.ImportBundleBlock)]
+    public class ImportBundleBlock : PipelineBlock<ImportEntityArgument, ImportEntityArgument, CommercePipelineExecutionContext>
+    {
+        private readonly CommerceCommander _commerceCommander;
+
+        public ImportBundleBlock(CommerceCommander commerceCommander)
+        {
+            _commerceCommander = commerceCommander;
+        }
+
+        public override async Task<ImportEntityArgument> Run(ImportEntityArgument arg, CommercePipelineExecutionContext context)
+        {
+            if (arg?.SourceEntity != null)
+            {
+                await ImportBundle(arg.ImportHandler.GetCommerceEntity(), arg, context)
+                    .ConfigureAwait(false);
+            }
+
+            return arg;
+        }
+
+        private async Task ImportBundle(CommerceEntity commerceEntity, ImportEntityArgument importEntityArgument, CommercePipelineExecutionContext context)
+        {
+            if (commerceEntity.HasComponent<BundleComponent>())
+            {
+                var bundleComponent = commerceEntity.GetComponent<BundleComponent>();
+
+                //get existing relationship data from IGetListsEntityIdsPipeline (super intuitive name)
+                var relationshipListNames = new[] {
+                    CatalogConstants.BundleToSellableItem,
+                    CatalogConstants.BundleToSellableItemVariant,
+                    CatalogConstants.SellableItemToBundle //TOOD - this is broken
+                };
+
+                relationshipListNames = relationshipListNames.Select(x =>
+                {
+                    x = $"{x}-{commerceEntity.FriendlyId}";
+                    if (commerceEntity.EntityVersion > 1)
+                    {
+                        x = $"{x}-{commerceEntity.EntityVersion}";
+                    }
+                    return x;
+                }).ToArray();
+
+                var existingRelationshipDictionary = await _commerceCommander.Pipeline<IGetListsEntityIdsPipeline>().Run(new GetListsEntityIdsArgument(relationshipListNames), context).ConfigureAwait(false);
+
+                //define a separate dictionary to store the "valid" relationships (this is used to remove orphaned relations later)
+                var newRelationshipDictionary = new Dictionary<string, List<string>>()
+                {
+                    { CatalogConstants.BundleToSellableItem, new List<string>() },
+                    { CatalogConstants.BundleToSellableItemVariant, new List<string>() }
+                };
+
+                //add new relationships
+                foreach (var bundleItem in bundleComponent.BundleItems)
+                {
+                    var isVariantRelationship = false;
+                    var sellableItemId = bundleItem.SellableItemId;
+                    if (bundleItem.SellableItemId.Contains('|'))
+                    {
+                        isVariantRelationship = true;
+                        sellableItemId = sellableItemId.Split('|')[0];
+                    }
+
+                    if (!isVariantRelationship)
+                    {
+                        newRelationshipDictionary[CatalogConstants.BundleToSellableItem].Add(sellableItemId);
+                    }
+                    else
+                    {
+                        newRelationshipDictionary[CatalogConstants.BundleToSellableItemVariant].Add(sellableItemId);
+                    }
+
+                    if (!isVariantRelationship && !HasRelationship(sellableItemId, CatalogConstants.BundleToSellableItem, existingRelationshipDictionary))
+                    {
+                        await CreateRelationship(commerceEntity.Id, sellableItemId, CatalogConstants.BundleToSellableItem, context);
+                    }
+                    else if (isVariantRelationship && !HasRelationship(sellableItemId, CatalogConstants.BundleToSellableItemVariant, existingRelationshipDictionary))
+                    {
+                        await CreateRelationship(commerceEntity.Id, sellableItemId, CatalogConstants.BundleToSellableItemVariant, context);
+                    }
+
+                    //TOOD - this is broken -- the SellableItemToBundle link does not come back on the query above
+                    //if (!HasRelationship(sellableItemId, CatalogConstants.SellableItemToBundle, relationshipDictionary))
+                    //{
+                    //    //create new sellable item to bundle relation
+                    //    await CreateRelationship(sellableItemId, commerceEntity.Id, CatalogConstants.SellableItemToBundle, context);
+                    //}
+                }
+
+                //remove orphaned relationships
+                var orphanedSellableItemIds = existingRelationshipDictionary.Single(dict => ParseRelationshipTypeFromKey(dict.Key) == CatalogConstants.BundleToSellableItem).Value.Where(x => !newRelationshipDictionary[CatalogConstants.BundleToSellableItem].Contains(x));
+                foreach (var sellableItemId in orphanedSellableItemIds)
+                {
+                    await DeleteRelationship(commerceEntity.Id, sellableItemId, CatalogConstants.BundleToSellableItem, context);
+                }
+
+                var orphanedSellableItemVariantIds = existingRelationshipDictionary.Single(dict => ParseRelationshipTypeFromKey(dict.Key) == CatalogConstants.BundleToSellableItemVariant).Value.Where(x => !newRelationshipDictionary[CatalogConstants.BundleToSellableItemVariant].Contains(x));
+                foreach (var sellableItemId in orphanedSellableItemVariantIds)
+                {
+                    await DeleteRelationship(commerceEntity.Id, sellableItemId, CatalogConstants.BundleToSellableItemVariant, context);
+                }
+            }
+        }
+
+        private async Task CreateRelationship(string source, string target, string relationshipType, CommercePipelineExecutionContext context)
+        {
+            var relationshipArg = new RelationshipArgument(source, target, relationshipType);
+            await _commerceCommander.Pipeline<ICreateRelationshipPipeline>().Run(relationshipArg, context).ConfigureAwait(false);
+        }
+
+        private async Task DeleteRelationship(string source, string target, string relationshipType, CommercePipelineExecutionContext context)
+        {
+            var relationshipArg = new RelationshipArgument(source, target, relationshipType);
+            await _commerceCommander.Pipeline<IDeleteRelationshipPipeline>().Run(relationshipArg, context).ConfigureAwait(false);
+        }
+
+        private bool HasRelationship(string target, string relationshipType, IDictionary<string, IList<string>> relationshipDictionary)
+        {
+            return relationshipDictionary.Any(dict => ParseRelationshipTypeFromKey(dict.Key) == relationshipType && dict.Value.Any(x => string.Equals(x, target, StringComparison.InvariantCultureIgnoreCase)));
+        }
+
+        private string ParseRelationshipTypeFromKey(string key)
+        {
+            //the key that comes back from IGetListsEntityIdsPipeline is formatted as follows: "List-BUNDLETOSELLABLEITEM-TESTBUNDLE01-ByDate"
+            //however, based on CreateBundleRelationshipsBlock, we need to use the values from CatalogConstants
+
+            var parts = key.Split('-');
+            var relationshipType = parts[1];
+
+            if (string.Equals(relationshipType, CatalogConstants.BundleToSellableItem, StringComparison.InvariantCultureIgnoreCase))
+            {
+                relationshipType = CatalogConstants.BundleToSellableItem;
+            }
+            else if (string.Equals(relationshipType, CatalogConstants.BundleToSellableItemVariant, StringComparison.InvariantCultureIgnoreCase))
+            {
+                relationshipType = CatalogConstants.BundleToSellableItemVariant;
+            }
+            else if (string.Equals(relationshipType, CatalogConstants.SellableItemToBundle, StringComparison.InvariantCultureIgnoreCase))
+            {
+                relationshipType = CatalogConstants.SellableItemToBundle;
+            }
+
+            return relationshipType;
+        }
+
+    }
+}

--- a/engine/Sitecore.Commerce.Engine/wwwroot/data/Environments/PlugIn.CatalogImport.PolicySet-1.0.0.json
+++ b/engine/Sitecore.Commerce.Engine/wwwroot/data/Environments/PlugIn.CatalogImport.PolicySet-1.0.0.json
@@ -96,11 +96,18 @@
               "ImportHandlerTypeName": "Plugin.Hunk.Catalog.Test.SellableItemEntityImport.SourceBundleImportHandler, Plugin.Hunk.Catalog.Test",
               "Components": {
                 "$type": "System.Collections.Generic.List`1[[System.String, mscorlib]], mscorlib",
-                "$values": []
+                "$values": [
+                  "BundleComponent"
+                ]
               }
             }
           ],
           "EntityComponentMappings": [
+            {
+              "$type": "Plugin.Hunk.Catalog.Policy.MapperType, Plugin.Hunk.Catalog",
+              "Key": "BundleComponent",
+              "FullTypeName": "Plugin.Hunk.Catalog.Test.SellableItemEntityImport.BundleComponentMapper, Plugin.Hunk.Catalog.Test"
+            },
             {
               "$type": "Plugin.Hunk.Catalog.Policy.MapperType, Plugin.Hunk.Catalog",
               "Key": "SellableItemComponent",

--- a/engine/Sitecore.Commerce.Engine/wwwroot/data/Environments/PlugIn.CatalogImport.PolicySet-1.0.0.json
+++ b/engine/Sitecore.Commerce.Engine/wwwroot/data/Environments/PlugIn.CatalogImport.PolicySet-1.0.0.json
@@ -89,6 +89,15 @@
               "Key": "SellableItemInventory",
               "ImportHandlerTypeName": "Plugin.Hunk.Catalog.ImportHandlers.SellableItemInventoryImportHandler, Plugin.Hunk.Catalog",
               "BulkImporterTypeName": "Plugin.Hunk.Catalog.BulkImport.SellableItemInventoryImport, Plugin.Hunk.Catalog"
+            },
+            {
+              "$type": "Plugin.Hunk.Catalog.Policy.EntityMapperType, Plugin.Hunk.Catalog",
+              "Key": "Bundle",
+              "ImportHandlerTypeName": "Plugin.Hunk.Catalog.Test.SellableItemEntityImport.SourceBundleImportHandler, Plugin.Hunk.Catalog.Test",
+              "Components": {
+                "$type": "System.Collections.Generic.List`1[[System.String, mscorlib]], mscorlib",
+                "$values": []
+              }
             }
           ],
           "EntityComponentMappings": [

--- a/postman/import/Catalog Import.postman_collection.json
+++ b/postman/import/Catalog Import.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "0a84967b-960a-48d6-b781-585d97284de4",
+		"_postman_id": "2ea53dd1-4438-4045-9b6a-bbdfcb710731",
 		"name": "Catalog Import",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -61,7 +61,10 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"Catalog\",\n\t\t\"Components\":[],\n\t\t\"VariantComponents\":[]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Hunk1_Catalog\",\n\t\t\"Name\": \"Hunk1_Catalog\",\n\t\t\"DisplayName\": \"Hunk1 Catalog Display Name\"\n\t}\n}"
+							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"Catalog\",\n\t\t\"Components\":[],\n\t\t\"VariantComponents\":[]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Hunk1_Catalog\",\n\t\t\"Name\": \"Hunk1_Catalog\",\n\t\t\"DisplayName\": \"Hunk1 Catalog Display Name\"\n\t}\n}",
+							"options": {
+								"raw": {}
+							}
 						},
 						"url": {
 							"raw": "{{ServiceHost}}/{{ShopsApi}}/ImportEntity()",
@@ -94,7 +97,10 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"minionFullName\":\"Plugin.Hunk.Catalog.Minions.BulkImportMinion, Plugin.Hunk.Catalog\",\n    \"environmentName\": \"HabitatCatalogImport\",\n    \"policies\": [\n    ]\n}"
+							"raw": "{\n    \"minionFullName\":\"Plugin.Hunk.Catalog.Minions.BulkImportMinion, Plugin.Hunk.Catalog\",\n    \"environmentName\": \"HabitatCatalogImport\",\n    \"policies\": [\n    ]\n}",
+							"options": {
+								"raw": {}
+							}
 						},
 						"url": {
 							"raw": "{{ServiceHost}}/{{OpsApi}}/RunMinion()",
@@ -162,7 +168,10 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"Catalog\",\n\t\t\"Components\":[],\n\t\t\"VariantComponents\":[]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Hunk1_Catalog\",\n\t\t\"Name\": \"Hunk1_Catalog\",\n\t\t\"DisplayName\": \"Hunk1 Catalog Display Name\",\n\t\t\"PriceBookName\": \"Hunk1_PriceBook\",\n\t\t\"PromotionBookName\": \"Hunk1_PromotionBook\",\n\t\t\"InventorySetName\": \"Hunk1_Inventory\"\n\t}\n}"
+							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"Catalog\",\n\t\t\"Components\":[],\n\t\t\"VariantComponents\":[]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Hunk1_Catalog\",\n\t\t\"Name\": \"Hunk1_Catalog\",\n\t\t\"DisplayName\": \"Hunk1 Catalog Display Name\",\n\t\t\"PriceBookName\": \"Hunk1_PriceBook\",\n\t\t\"PromotionBookName\": \"Hunk1_PromotionBook\",\n\t\t\"InventorySetName\": \"Hunk1_Inventory\"\n\t}\n}",
+							"options": {
+								"raw": {}
+							}
 						},
 						"url": {
 							"raw": "{{ServiceHost}}/{{ShopsApi}}/ImportEntity()",
@@ -230,7 +239,10 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"PriceBook\",\n\t\t\"Components\":[],\n\t\t\"VariantComponents\":[]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Hunk1_PriceBook\",\n\t\t\"Name\": \"Hunk1_PriceBook\",\n\t\t\"DisplayName\": \"Hunk1 Price Book Display Name\",\n\t\t\"Description\": \"Hunk1 Price Book Description\"\n\t}\n}"
+							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"PriceBook\",\n\t\t\"Components\":[],\n\t\t\"VariantComponents\":[]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Hunk1_PriceBook\",\n\t\t\"Name\": \"Hunk1_PriceBook\",\n\t\t\"DisplayName\": \"Hunk1 Price Book Display Name\",\n\t\t\"Description\": \"Hunk1 Price Book Description\"\n\t}\n}",
+							"options": {
+								"raw": {}
+							}
 						},
 						"url": {
 							"raw": "{{ServiceHost}}/{{ShopsApi}}/ImportEntity()",
@@ -298,7 +310,10 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"InventorySet\",\n\t\t\"Components\":[],\n\t\t\"VariantComponents\":[]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Hunk1_Inventory\",\n\t\t\"Name\": \"Hunk1_Inventory\",\n\t\t\"DisplayName\": \"Hunk1 Inventory Display Name\",\n\t\t\"Description\": \"Hunk1 Inventory Description\"\n\t}\n}"
+							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"InventorySet\",\n\t\t\"Components\":[],\n\t\t\"VariantComponents\":[]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Hunk1_Inventory\",\n\t\t\"Name\": \"Hunk1_Inventory\",\n\t\t\"DisplayName\": \"Hunk1 Inventory Display Name\",\n\t\t\"Description\": \"Hunk1 Inventory Description\"\n\t}\n}",
+							"options": {
+								"raw": {}
+							}
 						},
 						"url": {
 							"raw": "{{ServiceHost}}/{{ShopsApi}}/ImportEntity()",
@@ -366,7 +381,10 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"PriceCard\",\n\t\t\"Components\":[],\n\t\t\"VariantComponents\":[]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Hunk1_PriceCard\",\n\t\t\"Name\": \"Hunk1_PriceCard\",\n\t\t\"DisplayName\": \"Hunk1 Price Card Display Name\",\n\t\t\"Description\": \"Hunk1 Price Card Description\",\n\t\t\"BookName\": \"Hunk1_PriceBook\"\n\t}\n}"
+							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"PriceCard\",\n\t\t\"Components\":[],\n\t\t\"VariantComponents\":[]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Hunk1_PriceCard\",\n\t\t\"Name\": \"Hunk1_PriceCard\",\n\t\t\"DisplayName\": \"Hunk1 Price Card Display Name\",\n\t\t\"Description\": \"Hunk1 Price Card Description\",\n\t\t\"BookName\": \"Hunk1_PriceBook\"\n\t}\n}",
+							"options": {
+								"raw": {}
+							}
 						},
 						"url": {
 							"raw": "{{ServiceHost}}/{{ShopsApi}}/ImportEntity()",
@@ -434,7 +452,10 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"PromotionBook\",\n\t\t\"Components\":[],\n\t\t\"VariantComponents\":[]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Hunk1_PromotionBook\",\n\t\t\"Name\": \"Hunk1_PromotionBook\",\n\t\t\"DisplayName\": \"Hunk1 Promotion Book Display Name\",\n\t\t\"Description\": \"Hunk1 Promotion Book Description\"\n\t}\n}"
+							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"PromotionBook\",\n\t\t\"Components\":[],\n\t\t\"VariantComponents\":[]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Hunk1_PromotionBook\",\n\t\t\"Name\": \"Hunk1_PromotionBook\",\n\t\t\"DisplayName\": \"Hunk1 Promotion Book Display Name\",\n\t\t\"Description\": \"Hunk1 Promotion Book Description\"\n\t}\n}",
+							"options": {
+								"raw": {}
+							}
 						},
 						"url": {
 							"raw": "{{ServiceHost}}/{{ShopsApi}}/ImportEntity()",
@@ -502,7 +523,10 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"Promotion\",\n\t\t\"Components\":[],\n\t\t\"VariantComponents\":[]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Hunk1_Promotion\",\n\t\t\"Name\": \"Hunk1_Promotion\",\n\t\t\"DisplayName\": \"Hunk1 Promotion Display Name\",\n\t\t\"Description\": \"Hunk1 Promotion Description\",\n\t\t\"BookName\": \"Hunk1_PromotionBook\",\n\t\t\"ValidFrom\": \"2019-11-20T10:00:00\",\n\t\t\"ValidTo\": \"2019-12-05T17:30:00\",\n\t\t\"Text\": \"$10 Off Cart (Coupon)\",\n\t\t\"CartText\": \"$10 Off Cart (Coupon)\",\n\t\t\"IsExclusive\": false\n\t}\n}"
+							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"Promotion\",\n\t\t\"Components\":[],\n\t\t\"VariantComponents\":[]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Hunk1_Promotion\",\n\t\t\"Name\": \"Hunk1_Promotion\",\n\t\t\"DisplayName\": \"Hunk1 Promotion Display Name\",\n\t\t\"Description\": \"Hunk1 Promotion Description\",\n\t\t\"BookName\": \"Hunk1_PromotionBook\",\n\t\t\"ValidFrom\": \"2019-11-20T10:00:00\",\n\t\t\"ValidTo\": \"2019-12-05T17:30:00\",\n\t\t\"Text\": \"$10 Off Cart (Coupon)\",\n\t\t\"CartText\": \"$10 Off Cart (Coupon)\",\n\t\t\"IsExclusive\": false\n\t}\n}",
+							"options": {
+								"raw": {}
+							}
 						},
 						"url": {
 							"raw": "{{ServiceHost}}/{{ShopsApi}}/ImportEntity()",
@@ -570,7 +594,10 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"SellableItemInventory\",\n\t\t\"Components\":[],\n\t\t\"VariantComponents\":[]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Sellable Item\",\n\t\t\"VariantId\": \"Variant1\",\t\t\n\t\t\"InventorySetName\": \"Hunk1_Inventory\",\n\t\t\"InventoryDetail\": {\n\t\t\t\"Quantity\": 10000,\n\t\t\t\"InvoiceUnitPrice\": 100.54,\n\t\t\t\"InvoiceUnitPriceCurrency\": \"USD\",\n\t\t\t\"Preorderable\": true,\n\t\t\t\"PreorderAvailabilityDate\": \"2019-11-29T14:40:21\",\n\t\t\t\"PreorderLimit\": 5,\n\t\t\t\"Backorderable\": true,\n\t\t\t\"BackorderAvailabilityDate\": \"2019-12-05T00:10:00\",\n\t\t\t\"BackorderLimit\": 2\n\t\t}\n\t}\n}"
+							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"SellableItemInventory\",\n\t\t\"Components\":[],\n\t\t\"VariantComponents\":[]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Sellable Item\",\n\t\t\"VariantId\": \"Variant1\",\t\t\n\t\t\"InventorySetName\": \"Hunk1_Inventory\",\n\t\t\"InventoryDetail\": {\n\t\t\t\"Quantity\": 10000,\n\t\t\t\"InvoiceUnitPrice\": 100.54,\n\t\t\t\"InvoiceUnitPriceCurrency\": \"USD\",\n\t\t\t\"Preorderable\": true,\n\t\t\t\"PreorderAvailabilityDate\": \"2019-11-29T14:40:21\",\n\t\t\t\"PreorderLimit\": 5,\n\t\t\t\"Backorderable\": true,\n\t\t\t\"BackorderAvailabilityDate\": \"2019-12-05T00:10:00\",\n\t\t\t\"BackorderLimit\": 2\n\t\t}\n\t}\n}",
+							"options": {
+								"raw": {}
+							}
 						},
 						"url": {
 							"raw": "{{ServiceHost}}/{{ShopsApi}}/ImportEntity()",
@@ -638,7 +665,10 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"SellableItemRelationship\",\n\t\t\"Components\":[],\n\t\t\"VariantComponents\":[]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Sellable Item\",\n\t\t\"RelationshipDetails\": [\n\t\t\t{\n\t\t\t\t\"Name\": \"TrainingProducts\",\n\t\t\t\t\"Ids\":[\"6042325\",\"6042283\"]\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"Name\": \"InstallationProducts\",\n\t\t\t\t\"Ids\":[\"6042878\",\"6042183\"]\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"Name\": \"RelatedProducts\",\n\t\t\t\t\"Ids\":[\"6042430\",\"6042886\"]\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"Name\": \"WarrantyProducts\",\n\t\t\t\t\"Ids\":[\"7042257\",\"7042258\"]\n\t\t\t}\n\t\t]\n\t}\n}"
+							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"SellableItemRelationship\",\n\t\t\"Components\":[],\n\t\t\"VariantComponents\":[]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Sellable Item\",\n\t\t\"RelationshipDetails\": [\n\t\t\t{\n\t\t\t\t\"Name\": \"TrainingProducts\",\n\t\t\t\t\"Ids\":[\"6042325\",\"6042283\"]\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"Name\": \"InstallationProducts\",\n\t\t\t\t\"Ids\":[\"6042878\",\"6042183\"]\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"Name\": \"RelatedProducts\",\n\t\t\t\t\"Ids\":[\"6042430\",\"6042886\"]\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"Name\": \"WarrantyProducts\",\n\t\t\t\t\"Ids\":[\"7042257\",\"7042258\"]\n\t\t\t}\n\t\t]\n\t}\n}",
+							"options": {
+								"raw": {}
+							}
 						},
 						"url": {
 							"raw": "{{ServiceHost}}/{{ShopsApi}}/ImportEntity()",
@@ -706,7 +736,10 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"Catalog\",\n\t\t\"Components\":[],\n\t\t\"VariantComponents\":[]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Hunk1_Catalog\",\n\t\t\"Name\": \"Hunk1_Catalog\",\n\t\t\"DisplayName\": \"Hunk1 Catalog Display Name\",\n\t\t\"Languages\":[\n\t\t\t{\n\t\t\t\t\"Language\":\"fr-FR\",\n\t\t\t\t\"Entity\":{\n\t\t\t\t\t\"DisplayName\": \"fr-FR Hunk1 Catalog Display Name\",\n\t\t\t\t}\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"Language\":\"de-DE\",\n\t\t\t\t\"Entity\":{\n\t\t\t\t\t\"DisplayName\": \"de-DE Hunk1 Catalog Display Name\",\n\t\t\t\t}\n\t\t\t}\n\t\t]\n\t}\n}"
+							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"Catalog\",\n\t\t\"Components\":[],\n\t\t\"VariantComponents\":[]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Hunk1_Catalog\",\n\t\t\"Name\": \"Hunk1_Catalog\",\n\t\t\"DisplayName\": \"Hunk1 Catalog Display Name\",\n\t\t\"Languages\":[\n\t\t\t{\n\t\t\t\t\"Language\":\"fr-FR\",\n\t\t\t\t\"Entity\":{\n\t\t\t\t\t\"DisplayName\": \"fr-FR Hunk1 Catalog Display Name\",\n\t\t\t\t}\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"Language\":\"de-DE\",\n\t\t\t\t\"Entity\":{\n\t\t\t\t\t\"DisplayName\": \"de-DE Hunk1 Catalog Display Name\",\n\t\t\t\t}\n\t\t\t}\n\t\t]\n\t}\n}",
+							"options": {
+								"raw": {}
+							}
 						},
 						"url": {
 							"raw": "{{ServiceHost}}/{{ShopsApi}}/ImportEntity()",
@@ -774,7 +807,10 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"SourceCustomEntity\",\n\t\t\"Components\":[],\n\t\t\"VariantComponents\":[]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Custom Entity1\",\n\t\t\"Name\": \"Custom Entity1 Name\",\n\t\t\"DisplayName\": \"Custom Entity1 Display Name\",\n\t\t\"Description\": \"Custom Entity1 Description\"\n\t}\n}"
+							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"SourceCustomEntity\",\n\t\t\"Components\":[],\n\t\t\"VariantComponents\":[]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Custom Entity1\",\n\t\t\"Name\": \"Custom Entity1 Name\",\n\t\t\"DisplayName\": \"Custom Entity1 Display Name\",\n\t\t\"Description\": \"Custom Entity1 Description\"\n\t}\n}",
+							"options": {
+								"raw": {}
+							}
 						},
 						"url": {
 							"raw": "{{ServiceHost}}/{{ShopsApi}}/ImportEntity()",
@@ -842,7 +878,10 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"SourceCustomEntity\",\n\t\t\"Components\":[],\n\t\t\"VariantComponents\":[]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Custom Entity1\",\n\t\t\"Name\": \"Custom Entity1 Name\",\n\t\t\"DisplayName\": \"Custom Entity1 Display Name\",\n\t\t\"Description\": \"Custom Entity1 Description\",\n\t\t\"Languages\":[\n\t\t\t{\n\t\t\t\t\"Language\":\"fr-FR\",\n\t\t\t\t\"Entity\":{\n\t\t\t\t\t\"DisplayName\": \"fr-FR Custom Entity1 Display Name\",\n\t\t\t\t\t\"Description\": \"fr-FR Custom Entity1 Description\",\n\t\t\t\t}\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"Language\":\"de-DE\",\n\t\t\t\t\"Entity\":{\n\t\t\t\t\t\"DisplayName\": \"de-DE Custom Entity1 Display Name\",\n\t\t\t\t\t\"Description\": \"de-DE Custom Entity1 Description\",\n\t\t\t\t}\n\t\t\t}\n\t\t]\n\t}\n}"
+							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"SourceCustomEntity\",\n\t\t\"Components\":[],\n\t\t\"VariantComponents\":[]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Custom Entity1\",\n\t\t\"Name\": \"Custom Entity1 Name\",\n\t\t\"DisplayName\": \"Custom Entity1 Display Name\",\n\t\t\"Description\": \"Custom Entity1 Description\",\n\t\t\"Languages\":[\n\t\t\t{\n\t\t\t\t\"Language\":\"fr-FR\",\n\t\t\t\t\"Entity\":{\n\t\t\t\t\t\"DisplayName\": \"fr-FR Custom Entity1 Display Name\",\n\t\t\t\t\t\"Description\": \"fr-FR Custom Entity1 Description\",\n\t\t\t\t}\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"Language\":\"de-DE\",\n\t\t\t\t\"Entity\":{\n\t\t\t\t\t\"DisplayName\": \"de-DE Custom Entity1 Display Name\",\n\t\t\t\t\t\"Description\": \"de-DE Custom Entity1 Description\",\n\t\t\t\t}\n\t\t\t}\n\t\t]\n\t}\n}",
+							"options": {
+								"raw": {}
+							}
 						},
 						"url": {
 							"raw": "{{ServiceHost}}/{{ShopsApi}}/ImportEntity()",
@@ -910,7 +949,10 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"Category\",\n\t\t\"Components\":[],\n\t\t\"VariantComponents\":[]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Hunk1_Category Name\",\n\t\t\"Name\": \"Hunk1_Category Name\",\n\t\t\"DisplayName\": \"Hunk1 Category Display Name\",\n\t\t\"Description\": \"Hunk1 Category Description\",\n\t\t\"Parents\": [\"Hunk1_Catalog\"]\n\t}\n}"
+							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"Category\",\n\t\t\"Components\":[],\n\t\t\"VariantComponents\":[]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Hunk1_Category Name\",\n\t\t\"Name\": \"Hunk1_Category Name\",\n\t\t\"DisplayName\": \"Hunk1 Category Display Name\",\n\t\t\"Description\": \"Hunk1 Category Description\",\n\t\t\"Parents\": [\"Hunk1_Catalog\"]\n\t}\n}",
+							"options": {
+								"raw": {}
+							}
 						},
 						"url": {
 							"raw": "{{ServiceHost}}/{{ShopsApi}}/ImportEntity()",
@@ -978,7 +1020,10 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"Category\",\n\t\t\"Components\":[],\n\t\t\"VariantComponents\":[]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Hunk1_Category Name\",\n\t\t\"Name\": \"Hunk1_Category Name\",\n\t\t\"DisplayName\": \"Hunk1 Category Display Name\",\n\t\t\"Description\": \"Hunk1 Category Description\",\n\t\t\"Parents\": [\"Hunk1_Catalog\"],\n\t\t\"Languages\":[\n\t\t\t{\n\t\t\t\t\"Language\":\"fr-FR\",\n\t\t\t\t\"Entity\":{\n\t\t\t\t\t\"DisplayName\": \"fr-FR Hunk1 Category Display Name\",\n\t\t\t\t\t\"Description\": \"fr-FR Hunk1 Category Description\"\n\t\t\t\t}\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"Language\":\"de-DE\",\n\t\t\t\t\"Entity\":{\n\t\t\t\t\t\"DisplayName\": \"de-DE Hunk1 Category Display Name\",\n\t\t\t\t\t\"Description\": \"de-DE Hunk1 Category Description\"\n\t\t\t\t}\n\t\t\t}\n\t\t]\n\t}\n}"
+							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"Category\",\n\t\t\"Components\":[],\n\t\t\"VariantComponents\":[]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Hunk1_Category Name\",\n\t\t\"Name\": \"Hunk1_Category Name\",\n\t\t\"DisplayName\": \"Hunk1 Category Display Name\",\n\t\t\"Description\": \"Hunk1 Category Description\",\n\t\t\"Parents\": [\"Hunk1_Catalog\"],\n\t\t\"Languages\":[\n\t\t\t{\n\t\t\t\t\"Language\":\"fr-FR\",\n\t\t\t\t\"Entity\":{\n\t\t\t\t\t\"DisplayName\": \"fr-FR Hunk1 Category Display Name\",\n\t\t\t\t\t\"Description\": \"fr-FR Hunk1 Category Description\"\n\t\t\t\t}\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"Language\":\"de-DE\",\n\t\t\t\t\"Entity\":{\n\t\t\t\t\t\"DisplayName\": \"de-DE Hunk1 Category Display Name\",\n\t\t\t\t\t\"Description\": \"de-DE Hunk1 Category Description\"\n\t\t\t\t}\n\t\t\t}\n\t\t]\n\t}\n}",
+							"options": {
+								"raw": {}
+							}
 						},
 						"url": {
 							"raw": "{{ServiceHost}}/{{ShopsApi}}/ImportEntity()",
@@ -1046,7 +1091,81 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"SellableItem\",\n\t\t\"Components\":[\"SellableItemComponent\"],\n\t\t\"VariantComponents\":[\"VariantComponent\"]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Sellable Item1\",\n\t\t\"Name\": \"Sellable Item1\",\n\t\t\"DisplayName\": \"Sellable Item1 Display Name\",\n\t\t\"Description\": \"Sellable Item1 Description\",\n\t\t\"Brand\": \"sample brand\",\n\t\t\"Manufacturer\": \"sample manufacturer\",\n\t\t\"TypeOfGood\": \"sample type of good\",\n\t\t\"Tags\":[{\"Name\":\"tag\"}],\n\t\t\"Parents\": [\"Hunk1_Catalog/Hunk1_Category Name\"],\n\t\t\"Accessories\": \"Accessories value\",\n\t\t\"Dimensions\": \"Dimensions value\"\n\t}\n}"
+							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"SellableItem\",\n\t\t\"Components\":[\"SellableItemComponent\"],\n\t\t\"VariantComponents\":[\"VariantComponent\"]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Sellable Item\",\n\t\t\"Name\": \"Sellable Item\",\n\t\t\"DisplayName\": \"Sellable Item Display Name\",\n\t\t\"Description\": \"Sellable Item Description\",\n\t\t\"Brand\": \"sample brand\",\n\t\t\"Manufacturer\": \"sample manufacturer\",\n\t\t\"TypeOfGood\": \"sample type of good\",\n\t\t\"Tags\":[{\"Name\":\"tag1\"}],\n\t\t\"Parents\": [\"Hunk1_Catalog/Hunk1_Category Name\"],\n\t\t\"Accessories\": \"Accessories value\",\n\t\t\"Dimensions\": \"Dimensions value\"\n\t}\n}",
+							"options": {
+								"raw": {}
+							}
+						},
+						"url": {
+							"raw": "{{ServiceHost}}/{{ShopsApi}}/ImportEntity()",
+							"host": [
+								"{{ServiceHost}}"
+							],
+							"path": [
+								"{{ShopsApi}}",
+								"ImportEntity()"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Import Bundle",
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "ShopName",
+								"type": "text",
+								"value": "{{ShopName}}"
+							},
+							{
+								"key": "ShopperId",
+								"type": "text",
+								"value": "{{ShopperId}}"
+							},
+							{
+								"key": "Language",
+								"type": "text",
+								"value": "{{Language}}"
+							},
+							{
+								"key": "Currency",
+								"type": "text",
+								"value": "{{Currency}}"
+							},
+							{
+								"key": "Environment",
+								"type": "text",
+								"value": "{{Environment}}"
+							},
+							{
+								"key": "GeoLocation",
+								"type": "text",
+								"value": "{{GeoLocation}}"
+							},
+							{
+								"key": "CustomerId",
+								"type": "text",
+								"value": "{{CustomerId}}"
+							},
+							{
+								"key": "Authorization",
+								"type": "text",
+								"value": "{{SitecoreIdToken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"Bundle\",\n\t\t\"Components\":[\"BundleComponent\"]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"TestBundle06\",\n\t\t\"Name\": \"TestBundle06\",\n\t\t\"DisplayName\": \"TestBundle06\",\n\t\t\"Description\": \"TestBundle06 Description\",\n\t\t\"Brand\": \"sample brand\",\n\t\t\"Manufacturer\": \"sample manufacturer\",\n\t\t\"TypeOfGood\": \"sample type of good\",\n\t\t\"Tags\":[{\"Name\":\"tag1\"}],\n\t\t\"Parents\": [\"Habitat_Master\"],\n\t\t\"BundleType\": \"Static\",\n\t\t\"BundleItems\": [\n\t\t\t{\n\t\t\t\t\"ItemId\": \"Entity-SellableItem-TestProduct01\",\n\t\t\t\t\"Quantity\": 7\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"ItemId\": \"Entity-SellableItem-TestProduct02\",\n\t\t\t\t\"Quantity\": 5\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"ItemId\": \"Entity-SellableItem-TestProduct01|TestVariant01\",\n\t\t\t\t\"Quantity\": 25\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"ItemId\": \"Entity-SellableItem-TestProduct02|TestVariant03\",\n\t\t\t\t\"Quantity\": 2\n\t\t\t}\n\t\t]\n\t}\n}",
+							"options": {
+								"raw": {}
+							}
 						},
 						"url": {
 							"raw": "{{ServiceHost}}/{{ShopsApi}}/ImportEntity()",
@@ -1114,7 +1233,10 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"SellableItem\",\n\t\t\"Components\":[\"SellableItemComponent\"],\n\t\t\"VariantComponents\":[\"VariantComponent\"]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Sellable Item\",\n\t\t\"Name\": \"Sellable Item\",\n\t\t\"DisplayName\": \"Sellable Item Display Name\",\n\t\t\"Description\": \"Sellable Item Description\",\n\t\t\"Brand\": \"sample brand\",\n\t\t\"Manufacturer\": \"sample manufacturer\",\n\t\t\"TypeOfGood\": \"sample type of good\",\n\t\t\"Tags\":[{\"Name\":\"tag1\"}],\n\t\t\"Parents\": [\"Hunk1_Catalog/Hunk1_Category Name\"],\n\t\t\"Accessories\": \"Accessories value\",\n\t\t\"Dimensions\": \"Dimensions value\",\n\t\t\"Variants\": [\n\t\t\t{\n\t\t\t\t\"Id\": \"Variant1\",\n\t\t\t\t\"DisplayName\": \"Variant1 Display Name\",\n\t\t\t\t\"Description\": \"Variant1 Description\",\n\t\t\t\t\"Disabled\": \"false\",\n\t\t\t\t\"Tags\": [{\"Name\": \"tag1\"}],\n\t\t\t\t\"Breadth\": \"10m\",\n\t\t\t\t\"Length\": \"100m\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"Id\": \"Variant2\",\n\t\t\t\t\"DisplayName\": \"Variant2 Display Name\",\n\t\t\t\t\"Description\": \"Variant2 Description\",\n\t\t\t\t\"Disabled\": \"false\",\n\t\t\t\t\"Tags\": [{\"Name\":\"22cuft\"}, {\"Name\":\"v2\", \"Excluded\": true}],\n\t\t\t\t\"Breadth\": \"20m\",\n\t\t\t\t\"Length\": \"200m\"\n\t\t\t}\n\t\t]\n\t}\n}"
+							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"SellableItem\",\n\t\t\"Components\":[\"SellableItemComponent\"],\n\t\t\"VariantComponents\":[\"VariantComponent\"]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"TestProduct01\",\n\t\t\"Name\": \"TestProduct01\",\n\t\t\"DisplayName\": \"TestProduct01\",\n\t\t\"Description\": \"TestProduct01 Description\",\n\t\t\"Brand\": \"sample brand\",\n\t\t\"Manufacturer\": \"sample manufacturer\",\n\t\t\"TypeOfGood\": \"sample type of good\",\n\t\t\"Tags\":[{\"Name\":\"tag1\"}],\n\t\t\"Parents\": [\"Habitat_Master\"],\n\t\t\"Accessories\": \"Accessories value\",\n\t\t\"Dimensions\": \"Dimensions value\",\n\t\t\"Variants\": [\n\t\t\t{\n\t\t\t\t\"Id\": \"TestVariant01\",\n\t\t\t\t\"DisplayName\": \"TestVariant01\",\n\t\t\t\t\"Description\": \"TestVariant01 Description\",\n\t\t\t\t\"Disabled\": \"false\",\n\t\t\t\t\"Tags\": [{\"Name\": \"tag1\"}],\n\t\t\t\t\"Breadth\": \"10m\",\n\t\t\t\t\"Length\": \"100m\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"Id\": \"TestVariant02\",\n\t\t\t\t\"DisplayName\": \"TestVariant02\",\n\t\t\t\t\"Description\": \"TestVariant02 Description\",\n\t\t\t\t\"Disabled\": \"false\",\n\t\t\t\t\"Tags\": [{\"Name\": \"tag1\"}],\n\t\t\t\t\"Breadth\": \"20m\",\n\t\t\t\t\"Length\": \"200m\"\n\t\t\t},\n\t\t]\n\t}\n}",
+							"options": {
+								"raw": {}
+							}
 						},
 						"url": {
 							"raw": "{{ServiceHost}}/{{ShopsApi}}/ImportEntity()",
@@ -1182,7 +1304,10 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"SellableItem\",\n\t\t\"Components\":[\"SellableItemComponent\"],\n\t\t\"VariantComponents\":[\"VariantComponent\"]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Sellable Item\",\n\t\t\"Name\": \"Sellable Item\",\n\t\t\"DisplayName\": \"Sellable Item Display Name\",\n\t\t\"Description\": \"Sellable Item Description\",\n\t\t\"Brand\": \"sample brand\",\n\t\t\"Manufacturer\": \"sample manufacturer\",\n\t\t\"TypeOfGood\": \"sample type of good\",\n\t\t\"Tags\":[{\"Name\":\"tag1\"}],\n\t\t\"Parents\": [\"Hunk1_Catalog/Hunk1_Category Name\"],\n\t\t\"Accessories\": \"Accessories value\",\n\t\t\"Dimensions\": \"Dimensions value\",\n\t\t\"InventorySetName\": \"Hunk1_Inventory\",\n\t\t\"Variants\": [\n\t\t\t{\n\t\t\t\t\"Id\": \"Variant1\",\n\t\t\t\t\"DisplayName\": \"Variant1 Display Name\",\n\t\t\t\t\"Description\": \"Variant1 Description\",\n\t\t\t\t\"Disabled\": \"false\",\n\t\t\t\t\"Tags\": [{\"Name\": \"tag1\"}],\n\t\t\t\t\"Breadth\": \"10m\",\n\t\t\t\t\"Length\": \"100m\",\n\t\t\t\t\"InventoryDetail\": {\n\t\t\t\t\t\"Quantity\": 150,\n\t\t\t\t\t\"InvoiceUnitPrice\": 200.50,\n\t\t\t\t\t\"InvoiceUnitPriceCurrency\": \"USD\"\n\t\t\t\t}\n\t\t\t}\n\t\t]\n\t}\n}"
+							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"SellableItem\",\n\t\t\"Components\":[\"SellableItemComponent\"],\n\t\t\"VariantComponents\":[\"VariantComponent\"]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Sellable Item\",\n\t\t\"Name\": \"Sellable Item\",\n\t\t\"DisplayName\": \"Sellable Item Display Name\",\n\t\t\"Description\": \"Sellable Item Description\",\n\t\t\"Brand\": \"sample brand\",\n\t\t\"Manufacturer\": \"sample manufacturer\",\n\t\t\"TypeOfGood\": \"sample type of good\",\n\t\t\"Tags\":[{\"Name\":\"tag1\"}],\n\t\t\"Parents\": [\"Hunk1_Catalog/Hunk1_Category Name\"],\n\t\t\"Accessories\": \"Accessories value\",\n\t\t\"Dimensions\": \"Dimensions value\",\n\t\t\"InventorySetName\": \"Hunk1_Inventory\",\n\t\t\"Variants\": [\n\t\t\t{\n\t\t\t\t\"Id\": \"Variant1\",\n\t\t\t\t\"DisplayName\": \"Variant1 Display Name\",\n\t\t\t\t\"Description\": \"Variant1 Description\",\n\t\t\t\t\"Disabled\": \"false\",\n\t\t\t\t\"Tags\": [{\"Name\": \"tag1\"}],\n\t\t\t\t\"Breadth\": \"10m\",\n\t\t\t\t\"Length\": \"100m\",\n\t\t\t\t\"InventoryDetail\": {\n\t\t\t\t\t\"Quantity\": 150,\n\t\t\t\t\t\"InvoiceUnitPrice\": 200.50,\n\t\t\t\t\t\"InvoiceUnitPriceCurrency\": \"USD\"\n\t\t\t\t}\n\t\t\t}\n\t\t]\n\t}\n}",
+							"options": {
+								"raw": {}
+							}
 						},
 						"url": {
 							"raw": "{{ServiceHost}}/{{ShopsApi}}/ImportEntity()",
@@ -1250,7 +1375,10 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"SellableItem\",\n\t\t\"Components\":[\"SellableItemComponent\"],\n\t\t\"VariantComponents\":[\"VariantComponent\"]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Sellable Item\",\n\t\t\"Name\": \"Sellable Item\",\n\t\t\"DisplayName\": \"Sellable Item Display Name\",\n\t\t\"Description\": \"Sellable Item Description\",\n\t\t\"Brand\": \"sample brand\",\n\t\t\"Manufacturer\": \"sample manufacturer\",\n\t\t\"TypeOfGood\": \"sample type of good\",\n\t\t\"Tags\":[{\"Name\":\"tag1\"}],\n\t\t\"Parents\": [\"Hunk1_Catalog/Hunk1_Category Name\"],\n\t\t\"Accessories\": \"Accessories value\",\n\t\t\"Dimensions\": \"Dimensions value\",\n\t\t\"Variants\": [\n\t\t\t{\n\t\t\t\t\"Id\": \"Variant1\",\n\t\t\t\t\"DisplayName\": \"Variant1 Display Name\",\n\t\t\t\t\"Description\": \"Variant1 Description\",\n\t\t\t\t\"Disabled\": \"true\",\n\t\t\t\t\"Tags\": [{\"Name\": \"stainless\"}, {\"Name\": \"v1\", \"Excluded\": true}],\n\t\t\t\t\"Breadth\": \"10m\",\n\t\t\t\t\"Length\": \"100m\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"Id\": \"Variant2\",\n\t\t\t\t\"DisplayName\": \"Variant2 Display Name\",\n\t\t\t\t\"Description\": \"Variant2 Description\",\n\t\t\t\t\"Disabled\": \"false\",\n\t\t\t\t\"Tags\": [{\"Name\":\"22cuft\"}, {\"Name\":\"v2\", \"Excluded\": true}],\n\t\t\t\t\"Breadth\": \"20m\",\n\t\t\t\t\"Length\": \"200m\"\n\t\t\t}\n\t\t],\n\t\t\"Languages\":[\n\t\t\t{\n\t\t\t\t\"Language\":\"fr-FR\",\n\t\t\t\t\"Entity\":{\n\t\t\t\t\t\"DisplayName\": \"fr-FR Sellable Item1 Display Name\",\n\t\t\t\t\t\"Description\": \"fr-FR Sellable Item1 Description\",\n\t\t\t\t\t\"Accessories\": \"fr-FR Accessories value\",\n\t\t\t\t\t\"Dimensions\": \"fr-FR Dimensions value\",\n\t\t\t\t\t\"Variants\": [\n\t\t\t\t\t\t{\n\t\t\t\t\t\t\t\"Id\": \"Variant1\",\n\t\t\t\t\t\t\t\"DisplayName\": \"fr-FR Variant1 Display Name\",\n\t\t\t\t\t\t\t\"Description\": \"fr-FR Variant1 Description\",\n\t\t\t\t\t\t\t\"Breadth\": \"fr-FR 10m\",\n\t\t\t\t\t\t\t\"Length\": \"fr-FR 100m\"\n\t\t\t\t\t\t},\n\t\t\t\t\t\t{\n\t\t\t\t\t\t\t\"Id\": \"Variant2\",\n\t\t\t\t\t\t\t\"DisplayName\": \"fr-FR Variant2 Display Name\",\n\t\t\t\t\t\t\t\"Description\": \"fr-FR Variant2 Description\",\n\t\t\t\t\t\t\t\"Breadth\": \"fr-FR 20m\",\n\t\t\t\t\t\t\t\"Length\": \"fr-FR 200m\"\n\t\t\t\t\t\t}\n\t\t\t\t\t]\n\t\t\t\t}\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"Language\":\"de-DE\",\n\t\t\t\t\"Entity\":{\n\t\t\t\t\t\"DisplayName\": \"de-DE Sellable Item2 Display Name\",\n\t\t\t\t\t\"Description\": \"de-DE Sellable Item2 Description\",\n\t\t\t\t\t\"Accessories\": \"de-DE Accessories value\",\n\t\t\t\t\t\"Dimensions\": \"de-DE Dimensions value\",\n\t\t\t\t\t\"Variants\": [\n\t\t\t\t\t\t{\n\t\t\t\t\t\t\t\"Id\": \"Variant1\",\n\t\t\t\t\t\t\t\"DisplayName\": \"de-DE Variant1 Display Name\",\n\t\t\t\t\t\t\t\"Description\": \"de-DE Variant1 Description\",\n\t\t\t\t\t\t\t\"Breadth\": \"de-DE 10m\",\n\t\t\t\t\t\t\t\"Length\": \"de-DE 100m\"\n\t\t\t\t\t\t},\n\t\t\t\t\t\t{\n\t\t\t\t\t\t\t\"Id\": \"Variant2\",\n\t\t\t\t\t\t\t\"DisplayName\": \"de-DE Variant2 Display Name\",\n\t\t\t\t\t\t\t\"Description\": \"de-DE Variant2 Description\",\n\t\t\t\t\t\t\t\"Breadth\": \"de-DE 20m\",\n\t\t\t\t\t\t\t\"Length\": \"de-DE 200m\"\n\t\t\t\t\t\t}\n\t\t\t\t\t]\n\t\t\t\t}\n\t\t\t}\n\t\t]\n\t}\n}"
+							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"SellableItem\",\n\t\t\"Components\":[\"SellableItemComponent\"],\n\t\t\"VariantComponents\":[\"VariantComponent\"]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Sellable Item\",\n\t\t\"Name\": \"Sellable Item\",\n\t\t\"DisplayName\": \"Sellable Item Display Name\",\n\t\t\"Description\": \"Sellable Item Description\",\n\t\t\"Brand\": \"sample brand\",\n\t\t\"Manufacturer\": \"sample manufacturer\",\n\t\t\"TypeOfGood\": \"sample type of good\",\n\t\t\"Tags\":[{\"Name\":\"tag1\"}],\n\t\t\"Parents\": [\"Hunk1_Catalog/Hunk1_Category Name\"],\n\t\t\"Accessories\": \"Accessories value\",\n\t\t\"Dimensions\": \"Dimensions value\",\n\t\t\"Variants\": [\n\t\t\t{\n\t\t\t\t\"Id\": \"Variant1\",\n\t\t\t\t\"DisplayName\": \"Variant1 Display Name\",\n\t\t\t\t\"Description\": \"Variant1 Description\",\n\t\t\t\t\"Disabled\": \"true\",\n\t\t\t\t\"Tags\": [{\"Name\": \"stainless\"}, {\"Name\": \"v1\", \"Excluded\": true}],\n\t\t\t\t\"Breadth\": \"10m\",\n\t\t\t\t\"Length\": \"100m\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"Id\": \"Variant2\",\n\t\t\t\t\"DisplayName\": \"Variant2 Display Name\",\n\t\t\t\t\"Description\": \"Variant2 Description\",\n\t\t\t\t\"Disabled\": \"false\",\n\t\t\t\t\"Tags\": [{\"Name\":\"22cuft\"}, {\"Name\":\"v2\", \"Excluded\": true}],\n\t\t\t\t\"Breadth\": \"20m\",\n\t\t\t\t\"Length\": \"200m\"\n\t\t\t}\n\t\t],\n\t\t\"Languages\":[\n\t\t\t{\n\t\t\t\t\"Language\":\"fr-FR\",\n\t\t\t\t\"Entity\":{\n\t\t\t\t\t\"DisplayName\": \"fr-FR Sellable Item1 Display Name\",\n\t\t\t\t\t\"Description\": \"fr-FR Sellable Item1 Description\",\n\t\t\t\t\t\"Accessories\": \"fr-FR Accessories value\",\n\t\t\t\t\t\"Dimensions\": \"fr-FR Dimensions value\",\n\t\t\t\t\t\"Variants\": [\n\t\t\t\t\t\t{\n\t\t\t\t\t\t\t\"Id\": \"Variant1\",\n\t\t\t\t\t\t\t\"DisplayName\": \"fr-FR Variant1 Display Name\",\n\t\t\t\t\t\t\t\"Description\": \"fr-FR Variant1 Description\",\n\t\t\t\t\t\t\t\"Breadth\": \"fr-FR 10m\",\n\t\t\t\t\t\t\t\"Length\": \"fr-FR 100m\"\n\t\t\t\t\t\t},\n\t\t\t\t\t\t{\n\t\t\t\t\t\t\t\"Id\": \"Variant2\",\n\t\t\t\t\t\t\t\"DisplayName\": \"fr-FR Variant2 Display Name\",\n\t\t\t\t\t\t\t\"Description\": \"fr-FR Variant2 Description\",\n\t\t\t\t\t\t\t\"Breadth\": \"fr-FR 20m\",\n\t\t\t\t\t\t\t\"Length\": \"fr-FR 200m\"\n\t\t\t\t\t\t}\n\t\t\t\t\t]\n\t\t\t\t}\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"Language\":\"de-DE\",\n\t\t\t\t\"Entity\":{\n\t\t\t\t\t\"DisplayName\": \"de-DE Sellable Item2 Display Name\",\n\t\t\t\t\t\"Description\": \"de-DE Sellable Item2 Description\",\n\t\t\t\t\t\"Accessories\": \"de-DE Accessories value\",\n\t\t\t\t\t\"Dimensions\": \"de-DE Dimensions value\",\n\t\t\t\t\t\"Variants\": [\n\t\t\t\t\t\t{\n\t\t\t\t\t\t\t\"Id\": \"Variant1\",\n\t\t\t\t\t\t\t\"DisplayName\": \"de-DE Variant1 Display Name\",\n\t\t\t\t\t\t\t\"Description\": \"de-DE Variant1 Description\",\n\t\t\t\t\t\t\t\"Breadth\": \"de-DE 10m\",\n\t\t\t\t\t\t\t\"Length\": \"de-DE 100m\"\n\t\t\t\t\t\t},\n\t\t\t\t\t\t{\n\t\t\t\t\t\t\t\"Id\": \"Variant2\",\n\t\t\t\t\t\t\t\"DisplayName\": \"de-DE Variant2 Display Name\",\n\t\t\t\t\t\t\t\"Description\": \"de-DE Variant2 Description\",\n\t\t\t\t\t\t\t\"Breadth\": \"de-DE 20m\",\n\t\t\t\t\t\t\t\"Length\": \"de-DE 200m\"\n\t\t\t\t\t\t}\n\t\t\t\t\t]\n\t\t\t\t}\n\t\t\t}\n\t\t]\n\t}\n}",
+							"options": {
+								"raw": {}
+							}
 						},
 						"url": {
 							"raw": "{{ServiceHost}}/{{ShopsApi}}/ImportEntity()",
@@ -1318,7 +1446,10 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"SellableItem\",\n\t\t\"Components\":[\"SellableItemComponent\"],\n\t\t\"VariantComponents\":[\"VariantComponent\"]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Sellable Item\",\n\t\t\"Name\": \"Sellable Item\",\n\t\t\"DisplayName\": \"Sellable Item Display Name\",\n\t\t\"Description\": \"Sellable Item Description\",\n\t\t\"Brand\": \"sample brand\",\n\t\t\"Manufacturer\": \"sample manufacturer\",\n\t\t\"TypeOfGood\": \"sample type of good\",\n\t\t\"Tags\":[{\"Name\":\"tag1\"}],\n\t\t\"Parents\": [\"Hunk1_Catalog/Hunk1_Category Name\"],\n\t\t\"Accessories\": \"Accessories value\",\n\t\t\"Dimensions\": \"Dimensions value\",\n\t\t\"Variants\": [\n\t\t\t{\n\t\t\t\t\"Id\": \"Variant1\",\n\t\t\t\t\"DisplayName\": \"Variant1 Display Name\",\n\t\t\t\t\"Description\": \"Variant1 Description\",\n\t\t\t\t\"Disabled\": \"true\",\n\t\t\t\t\"Tags\": [{\"Name\": \"stainless\"}, {\"Name\": \"v1\", \"Excluded\": true}],\n\t\t\t\t\"Breadth\": \"10m\",\n\t\t\t\t\"Length\": \"100m\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"Id\": \"Variant2\",\n\t\t\t\t\"DisplayName\": \"Variant2 Display Name\",\n\t\t\t\t\"Description\": \"Variant2 Description\",\n\t\t\t\t\"Disabled\": \"false\",\n\t\t\t\t\"Tags\": [{\"Name\":\"22cuft\"}, {\"Name\":\"v2\", \"Excluded\": true}],\n\t\t\t\t\"Breadth\": \"20m\",\n\t\t\t\t\"Length\": \"200m\"\n\t\t\t}\n\t\t],\n\t\t\"RelationshipDetails\": [\n\t\t\t{\n\t\t\t\t\"Name\": \"TrainingProducts\",\n\t\t\t\t\"Ids\":[\"6042325\",\"6042283\"]\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"Name\": \"InstallationProducts\",\n\t\t\t\t\"Ids\":[\"6042878\",\"6042183\"]\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"Name\": \"RelatedProducts\",\n\t\t\t\t\"Ids\":[\"6042430\",\"6042886\"]\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"Name\": \"WarrantyProducts\",\n\t\t\t\t\"Ids\":[\"7042257\",\"7042258\"]\n\t\t\t}\n\t\t]\n\t}\n}"
+							"raw": "{\n\t\"metadata\":{\n\t\t\"EntityType\":\"SellableItem\",\n\t\t\"Components\":[\"SellableItemComponent\"],\n\t\t\"VariantComponents\":[\"VariantComponent\"]\n\t},\n\t\"entity\": {\n\t\t\"Id\": \"Sellable Item\",\n\t\t\"Name\": \"Sellable Item\",\n\t\t\"DisplayName\": \"Sellable Item Display Name\",\n\t\t\"Description\": \"Sellable Item Description\",\n\t\t\"Brand\": \"sample brand\",\n\t\t\"Manufacturer\": \"sample manufacturer\",\n\t\t\"TypeOfGood\": \"sample type of good\",\n\t\t\"Tags\":[{\"Name\":\"tag1\"}],\n\t\t\"Parents\": [\"Hunk1_Catalog/Hunk1_Category Name\"],\n\t\t\"Accessories\": \"Accessories value\",\n\t\t\"Dimensions\": \"Dimensions value\",\n\t\t\"Variants\": [\n\t\t\t{\n\t\t\t\t\"Id\": \"Variant1\",\n\t\t\t\t\"DisplayName\": \"Variant1 Display Name\",\n\t\t\t\t\"Description\": \"Variant1 Description\",\n\t\t\t\t\"Disabled\": \"true\",\n\t\t\t\t\"Tags\": [{\"Name\": \"stainless\"}, {\"Name\": \"v1\", \"Excluded\": true}],\n\t\t\t\t\"Breadth\": \"10m\",\n\t\t\t\t\"Length\": \"100m\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"Id\": \"Variant2\",\n\t\t\t\t\"DisplayName\": \"Variant2 Display Name\",\n\t\t\t\t\"Description\": \"Variant2 Description\",\n\t\t\t\t\"Disabled\": \"false\",\n\t\t\t\t\"Tags\": [{\"Name\":\"22cuft\"}, {\"Name\":\"v2\", \"Excluded\": true}],\n\t\t\t\t\"Breadth\": \"20m\",\n\t\t\t\t\"Length\": \"200m\"\n\t\t\t}\n\t\t],\n\t\t\"RelationshipDetails\": [\n\t\t\t{\n\t\t\t\t\"Name\": \"TrainingProducts\",\n\t\t\t\t\"Ids\":[\"6042325\",\"6042283\"]\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"Name\": \"InstallationProducts\",\n\t\t\t\t\"Ids\":[\"6042878\",\"6042183\"]\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"Name\": \"RelatedProducts\",\n\t\t\t\t\"Ids\":[\"6042430\",\"6042886\"]\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"Name\": \"WarrantyProducts\",\n\t\t\t\t\"Ids\":[\"7042257\",\"7042258\"]\n\t\t\t}\n\t\t]\n\t}\n}",
+							"options": {
+								"raw": {}
+							}
 						},
 						"url": {
 							"raw": "{{ServiceHost}}/{{ShopsApi}}/ImportEntity()",


### PR DESCRIPTION
This PR adds support for creating/updating sellable item bundles.  A few notes:

- There is no support for bulk importing bundles (this was not a requirement for us, but it could be added)
- When triggering the import, "Bundle" must be specified as the EntityType and "BundleComponent" as one of the components.  This could probably be refactored to not require "BundleComponent" (similar to how the "VariantComponent" works for SellableItem).  This is demonstrated in the Postman collection and test project.
- The "_postman_id" value in the collection JSON looks like it has changed.  I can change this back, if desired -- not sure how best to handle source control of Postman collections.